### PR TITLE
Fix coverity defects

### DIFF
--- a/src/bforce.c
+++ b/src/bforce.c
@@ -807,7 +807,7 @@ static int set_pwcfg(struct zc_crk_bforce *crk, const struct zc_crk_pwcfg *cfg)
 
 	if (cfg->mask.str) {
 		/* use mask */
-		char **parsed;
+		char **parsed = NULL;
 		int ret;
 		size_t parsed_len;
 		size_t mask_minlen;

--- a/src/mask_parser.y
+++ b/src/mask_parser.y
@@ -9,6 +9,14 @@
 #include "mask_scanner.h"
 #include "list.h"
 
+/*
+ * Both repeating productions below are left-recursive, so parser stack depth
+ * does not grow with mask length.  The initial Bison stack is therefore ample;
+ * keeping its maximum at the same size avoids unnecessary dynamic relocation.
+ */
+#define YYINITDEPTH 200
+#define YYMAXDEPTH YYINITDEPTH
+
 int yylex(void);
 void mask_scanner_reset(void);
 
@@ -215,6 +223,11 @@ int parse_mask(const char *input, char ***output)
 	YY_BUFFER_STATE buffer;
 	int ret;
 	char **tmp;
+	size_t copied = 0;
+
+	if (!input || !output)
+		return -1;
+	*output = NULL;
 
 	/* current_range is normally cleared when a complete range is reduced.
 	 * A previous syntax error may have interrupted that reduction. */
@@ -230,7 +243,7 @@ int parse_mask(const char *input, char ***output)
 	ret = yyparse();
 	if (ret) {
 		ret = -1;
-		goto err_del_buffer;
+		goto err_dealloc_items;
 	}
 
 	list_for_each_entry(item, &item_head, list)
@@ -242,11 +255,20 @@ int parse_mask(const char *input, char ***output)
 		goto err_dealloc_items;
 	}
 
-	ret = 0;
 	list_for_each_entry(item, &item_head, list) {
-		tmp[ret++] = strdup(item->set);
+		tmp[copied] = strdup(item->set);
+		if (!tmp[copied]) {
+			yyerror("strdup() failed");
+			while (copied)
+				free(tmp[--copied]);
+			free(tmp);
+			ret = -1;
+			goto err_dealloc_items;
+		}
+		copied++;
 	}
 
+	ret = (int)copied;
 	*output = tmp;
 
 err_dealloc_items:
@@ -256,7 +278,6 @@ err_dealloc_items:
 		current_range = NULL;
 	}
 	dealloc_item_list(&item_head);
-err_del_buffer:
 	yy_delete_buffer(buffer);
 	return ret;
 }

--- a/tests/check_bruteforce.c
+++ b/tests/check_bruteforce.c
@@ -21,6 +21,7 @@
 #include <stdio.h>
 
 #include "libzc.h"
+#include "mask_parser.h"
 
 struct zc_crk_bforce *crk;
 
@@ -216,6 +217,39 @@ START_TEST(test_mask_parser_recovers_after_invalid_range)
 	cfg.mask.str = "p[b][s][s]";
 	ck_assert_int_eq(zc_crk_bforce_init(crk, DATADIR "stored.zip", &cfg), 0);
 	ck_assert_int_eq(zc_crk_bforce_start(crk, out, sizeof(out)), 1);
+}
+END_TEST
+
+START_TEST(test_mask_parser_failure_clears_output)
+{
+	char *sentinel = NULL;
+	char **parsed = &sentinel;
+
+	/* The literal is already on item_head and the leading range character is
+	 * held by current_range when the descending range aborts the parse. */
+	ck_assert_int_eq(parse_mask("a[az-a]", &parsed), -1);
+	ck_assert_ptr_null(parsed);
+}
+END_TEST
+
+START_TEST(test_mask_parser_long_input_uses_bounded_stack)
+{
+	enum { mask_len = 512 };
+	char mask[mask_len + 1];
+	char **parsed = NULL;
+
+	/* input is left-recursive, so parsing more symbols than YYINITDEPTH does
+	 * not require the generated parser to relocate its stacks. */
+	memset(mask, 'a', mask_len);
+	mask[mask_len] = '\0';
+
+	ck_assert_int_eq(parse_mask(mask, &parsed), mask_len);
+	ck_assert_ptr_nonnull(parsed);
+	for (size_t i = 0; i < mask_len; ++i) {
+		ck_assert_str_eq(parsed[i], "a");
+		free(parsed[i]);
+	}
+	free(parsed);
 }
 END_TEST
 
@@ -668,6 +702,8 @@ Suite *bforce_suite(void)
 	tcase_add_test(tc_core, test_reject_initial_password_outside_set);
 	tcase_add_test(tc_core, test_reject_initial_password_outside_mask);
 	tcase_add_test(tc_core, test_mask_parser_recovers_after_invalid_range);
+	tcase_add_test(tc_core, test_mask_parser_failure_clears_output);
+	tcase_add_test(tc_core, test_mask_parser_long_input_uses_bounded_stack);
 	tcase_add_test(tc_core, test_mask_parser_rejects_nul);
 	tcase_add_test(tc_core, test_bruteforce_password_found);
 	tcase_add_test(tc_core, test_bruteforce_password_found_multicall);


### PR DESCRIPTION
Details:

** CID 563452:       Resource leaks  (RESOURCE_LEAK)
/src/bforce.c: 819           in set_pwcfg()

_____________________________________________________________________________________________
*** CID 563452:         Resource leaks  (RESOURCE_LEAK)
/src/bforce.c: 819             in set_pwcfg()
813     		size_t mask_minlen;
814     		size_t mask_maxlen;
815
816     		ret = parse_mask(cfg->mask.str, &parsed);
817     		if (ret <= 0) {
818     			err("mask parsing failed!\n");
>>>     CID 563452:         Resource leaks  (RESOURCE_LEAK)
>>>     Variable "parsed" going out of scope leaks the storage it points to.
819     			return -1;
820     		}
821
822     		parsed_len = (size_t)ret;
823     		mask_minlen = cfg->mask.minlen ? cfg->mask.minlen : parsed_len;
824     		mask_maxlen = cfg->mask.maxlen ? cfg->mask.maxlen : parsed_len;

** CID 214497:       Memory - corruptions  (OVERRUN)
/src/mask_parser.c: 1276           in yyparse()

_____________________________________________________________________________________________
*** CID 214497:         Memory - corruptions  (OVERRUN)
/src/mask_parser.c: 1276             in yyparse()
1270
1271           YY_IGNORE_USELESS_CAST_BEGIN
1272           YYDPRINTF ((stderr, "Stack size increased to %ld\n",
1273                       YY_CAST (long, yystacksize)));
1274           YY_IGNORE_USELESS_CAST_END
1275
>>>     CID 214497:         Memory - corruptions  (OVERRUN)
>>>     "yyss + yystacksize - 1" evaluates to an address that is at byte offset 9999 of an array of 8 bytes.
1276           if (yyss + yystacksize - 1 <= yyssp)
1277             YYABORT;
1278         }
1279     #endif /* !defined yyoverflow && !defined YYSTACK_RELOCATE */
1280
1281

** CID 37933:       Memory - corruptions  (ARRAY_VS_SINGLETON)
/src/mask_parser.c: 1268           in yyparse()

_____________________________________________________________________________________________
*** CID 37933:         Memory - corruptions  (ARRAY_VS_SINGLETON)
/src/mask_parser.c: 1268             in yyparse()
1262     #  undef YYSTACK_RELOCATE
1263             if (yyss1 != yyssa)
1264               YYSTACK_FREE (yyss1);
1265           }
1266     # endif
1267
>>>     CID 37933:         Memory - corruptions  (ARRAY_VS_SINGLETON)
>>>     Using "yyss" as an array.  This might corrupt or misinterpret adjacent memory locations.
1268           yyssp = yyss + yysize - 1;
1269           yyvsp = yyvs + yysize - 1;
1270
1271           YY_IGNORE_USELESS_CAST_BEGIN
1272           YYDPRINTF ((stderr, "Stack size increased to %ld\n",
1273                       YY_CAST (long, yystacksize)));